### PR TITLE
Removed the Broken YouTube Link, Added the correct Link

### DIFF
--- a/_includes/icons.html
+++ b/_includes/icons.html
@@ -160,7 +160,7 @@
 
 {% if site.theme_settings.youtube %}
 <li>
-	<a href="https://www.youtube.com/user/{{ site.theme_settings.youtube }}" title="{{ site.theme_settings.str_follow_on }} YouTube">
+	<a href="https://www.youtube.com/channel/UCICWIYEx2mo4wYZzLwJ7wVw" title="{{ site.theme_settings.str_follow_on }} YouTube">
 		<i class="fa fa-fw fa-youtube"></i>
 	</a>
 </li>


### PR DESCRIPTION
The YouTube Link was broken. The broken link has been removed and the valid link of Coding Blocks has been added.